### PR TITLE
[FEATURE] Ajouter un saut de ligne entre les éléments

### DIFF
--- a/config.js
+++ b/config.js
@@ -56,6 +56,12 @@ export default [
       ],
       'no-var': ['error'],
       'object-curly-spacing': ['error', 'always'],
+      'padding-line-between-statements': [
+        'error',
+        { blankLine: 'always', prev: 'block', next: 'block' },
+        { blankLine: 'always', prev: 'function', next: 'function' },
+        { blankLine: 'always', prev: 'class', next: 'function' }
+      ],
       'prefer-const': ['error'],
       quotes: ['error', 'single'],
       semi: ['error', 'always'],


### PR DESCRIPTION
## :pancakes: Problème

Lorsqu'on écrit des testes ou même des fichiers standard, il arrive qu'on oublie de sauter des lignes entre les fonctions, classes, etc. Cela est pourtant plus confortable à lire et rend le code plus compréhensible.

## :bacon: Proposition

Ajouter une règle de linting qui met une ligne vide entre les testes, les fonctions et les classes.

## 🧃 Remarques

Cela va impacter pas mal de fichier notamment dans le mono-repos.

## :yum: Pour tester
- Cloner le dépôt,
- Installer les dépendances:
```shell
npm ci
```
- Rendre le projet disponible en local:
```shell
npm link
```
- Ouvrir l'API du mono-repos par exemple,
- Utiliser le projet local:
```shell
npm link @1024pix/eslint-plugin
```
- Modifier un fichier de teste en retirant une ligne vide entre 2 testes,
- Exécuter le lint avec l'option fix:
```shell
npm run lint:fix
````
- Constater qu'une ligne a été rajoutée,
- Faire de la même manière pour 2 fonctions et 2 classes.